### PR TITLE
Always extract dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[easy_install]
+zip_ok = 0


### PR DESCRIPTION
easy_install will install eggs zipped unless they set the zip_safe flag to false. However, many django apps do not set this flag, yet include static files that can only be found by `python manage.py collectstatic` if the egg was extracted.
